### PR TITLE
Fix webpack regex embed comment termination

### DIFF
--- a/webpack-plugin/src/validateOptions.js
+++ b/webpack-plugin/src/validateOptions.js
@@ -4,7 +4,8 @@
 function validateOptions(options) {
   // Default options to our preferred value
   options.dest = options.dest || 'carte-blanche';
-  options.filter = options.filter || /([A-Z][a-zA-Z]*\/index|[A-Z][a-zA-Z]*)\.(jsx?|es6|react\.jsx?)$/;
+  // HACK: Webpack can embed this regex verbatim and the .? makes it not insert a comment terminator
+  options.filter = options.filter || /([A-Z][a-zA-Z]*.?\/index|[A-Z][a-zA-Z]*)\.(jsx?|es6|react\.jsx?)$/;
 
   // Assert that the componentRoot option was specified
   if (!options.componentRoot) {


### PR DESCRIPTION
Webpack has no protection against inserting */ in the comments it writes when output.pathinfo is true